### PR TITLE
Modify 41.2.17.scm

### DIFF
--- a/41/41.2.17.scm
+++ b/41/41.2.17.scm
@@ -16,11 +16,11 @@
   (cond [(zero? i) (void)]
         [else
           (begin
-            (vector-set! v (sub1 i) (f (vector-ref v (sub1 i))))
+            (vector-set! v (sub1 i) (f (vector-ref v (sub1 i)) (sub1 i)))
             (vec-for-all-aux f v (sub1 i)))]))
 
 (define (vector*! s v)
-  (vec-for-all (lambda (x) (* x s)) v))
+  (vec-for-all (lambda (value index) (* value s)) v))
 
 (require rackunit)
 (require rackunit/text-ui)


### PR DESCRIPTION
The vector mutator function needs to accept the index as well if it is to be an abstraction that can be applied to functions such as move! from the previous exercise, since move! makes use of index value to access another array in tandem.
